### PR TITLE
Bugfixes for Functions 'times' and 'or' in lang Package

### DIFF
--- a/src/main/scala/daisy/lang/Constructors.scala
+++ b/src/main/scala/daisy/lang/Constructors.scala
@@ -58,8 +58,8 @@ object Constructors {
     }
 
     simpler match {
-      case collection.mutable.Seq()  => BooleanLiteral(false)
-      case collection.mutable.Seq(x) => simpler(0)
+      case Seq()  => BooleanLiteral(false)
+      case Seq(x) => simpler(0)
       case _      => Or(Seq(simpler: _*)) // make immutable Seq
     }
   }
@@ -120,12 +120,12 @@ object Constructors {
   def times(lhs: Expr, rhs: Expr): Expr = (lhs, rhs) match {
     case (IntegerLiteral(bi), _) if bi == 1 => rhs
     case (_, IntegerLiteral(bi)) if bi == 1 => lhs
-    case (IntegerLiteral(bi), _) if bi == 0 => IntegerLiteral(0)
-    case (_, IntegerLiteral(bi)) if bi == 0 => IntegerLiteral(0)
+    // case (IntegerLiteral(bi), _) if bi == 0 => IntegerLiteral(0)
+    // case (_, IntegerLiteral(bi)) if bi == 0 => IntegerLiteral(0)
     case (Int32Literal(1), _) => rhs
     case (_, Int32Literal(1)) => lhs
-    case (Int32Literal(0), _) => Int32Literal(0)
-    case (_, Int32Literal(0)) => Int32Literal(0)
+    // case (Int32Literal(0), _) => Int32Literal(0)
+    // case (_, Int32Literal(0)) => Int32Literal(0)
     // case (IsTyped(_, Int32Type), IsTyped(_, Int32Type)) => BVTimes(lhs, rhs)
     // case (IsTyped(_, RealType), IsTyped(_, RealType)) => RealTimes(lhs, rhs)
     case _ => Times(lhs, rhs)


### PR DESCRIPTION
This update fixes bugs in the lang package.

The optimisation over Times expressions ignores errors: commented out these cases.
The optimisation over Or expressions uses the wrong data structure to match against, which can cause a crash: changed data structure to Seq.

# Test Results Before Changes
```
[info] Run completed in 4 minutes, 38 seconds.
[info] Total number of tests run: 126
[info] Suites: completed 4, aborted 2
[info] Tests: succeeded 126, failed 0, canceled 0, ignored 0, pending 0
[info] *** 2 SUITES ABORTED ***
[error] Error: Total 97, Failed 0, Errors 2, Passed 95
[error] Error during tests:
[error]         regression.AbsErrorAnalysisRegressionTest
[error]         regression.PowTransformerRegressionTest
[error] (Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 284 s (04:44), completed Jun 19, 2025 3:16:17 PM
```

# Test Results After Changes
```
[info] ScalaTest
[info] Run completed in 4 minutes, 40 seconds.
[info] Total number of tests run: 126
[info] Suites: completed 4, aborted 2
[info] Tests: succeeded 126, failed 0, canceled 0, ignored 0, pending 0
[info] *** 2 SUITES ABORTED ***
[error] Error: Total 97, Failed 0, Errors 2, Passed 95
[error] Error during tests:
[error]         regression.AbsErrorAnalysisRegressionTest
[error]         regression.PowTransformerRegressionTest
[error] (Test / test) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 286 s (04:46), completed Jun 19, 2025 3:24:32 PM
```